### PR TITLE
Adds blue background to author details page

### DIFF
--- a/layouts/authors/list.html
+++ b/layouts/authors/list.html
@@ -11,7 +11,10 @@
       <div class="md:w-1/2 lg:w-1/3 md:pr-4 lg:pr-8">
         {{ range .Resources.Match "avatar" }}
           {{ $image := .Fill "250x250" }}
-          <img class="mb-4 rounded-full mx-auto w-64 h-64 md:ml-0 lg:mb-8" src="{{ $image.Permalink }}">
+          <div class="relative mb-4 lg:mb-8 md:ml-0">
+            <img class="absolute block rounded-full mx-auto w-64 h-64 mt-4 ml-4" src="{{ $image.Permalink }}" style="left: 50%; transform: translateX(-50%);">
+            <img class="mx-auto w-72 h-72" src="/images/people-bg-mask.png">
+          </div>
         {{ end }}
 
         <h3 class="text-center md:text-left mb-2 text-grey font-bold text-md leading-none">{{ .Params.name }}</h3>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,6 +23,9 @@ module.exports = {
       lineHeight: {
         cavernous: '3rem',
       },
+      spacing: {
+        72: '18rem',
+      },
     },
     // Do not extend these
     colors: {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1612785/71231673-d6624700-22a3-11ea-9bc8-706352b664c7.png)

![image](https://user-images.githubusercontent.com/1612785/71231656-cd717580-22a3-11ea-88a5-4ab7698a38be.png)

I thought desktop looked cool if the image was pulled left and broke the site container slightly, did not push this change, just a thought:
![image](https://user-images.githubusercontent.com/1612785/71231720-f85bc980-22a3-11ea-8f45-0b8ed1c213bb.png)

