### PR TITLE
Change how we display the talks research area

### DIFF
--- a/layouts/partials/talk-card.html
+++ b/layouts/partials/talk-card.html
@@ -8,7 +8,9 @@
 
   <a href="{{ .RelPermalink }}" class="block text-bigger font-bold py-2 hover:text-blue">{{ .Title }}</a>
 
-  {{ partial "talk-data-strip" . }}
+  <div class="mb-4">
+    {{ partial "talk-data-strip" . }}
+  </div>
 
   {{ partial "authors-row-large-with-name" . }}
 </div>

--- a/layouts/partials/talk-data-strip.html
+++ b/layouts/partials/talk-data-strip.html
@@ -1,10 +1,24 @@
-<div class="text-sm text-gray-600 mb-4">
-  <span>{{ dateFormat .Site.Params.DateForm .Params.publishDate }}</span>
+<div class="text-sm text-gray-600">{{ dateFormat .Site.Params.DateForm .Params.publishDate }}</div>
 
-  {{ range (index .Params "research-areas") }}
-    {{ with $.Site.GetPage "taxonomyTerm" (printf "research/areas/%s" (urlize .)) }}
-      <span class="text-blue-200">/</span>
-      <a class="inline-block capitalize hover:text-blue" href="{{ .Permalink }}">{{ humanize .Title }}</a>
+{{ if (index .Params "research-areas") }}
+  <div class="block">
+    <img class="inline-block mr-2" src="/images/icon/tag.svg">
+    {{ range $index, $value := (index .Params "research-areas") }}
+      {{ if gt $index 0 }}
+        <span class="text-gray-600">,</span>
+      {{ end }}
+      {{ with $.Site.GetPage "taxonomyTerm" (printf "research/areas/%s" (urlize $value )) }}
+        <a href="{{ .Permalink }}" class="inline-block text-sm text-gray-600 hover:text-blue">
+          <span class="underline capitalize">{{ humanize .Title }}</span>
+        </a>
+      {{ end }}
     {{ end }}
-  {{end}}
-</div>
+  </div>
+{{ end }}
+
+{{ if .Params.location }}
+  <div class="text-sm text-gray-600">
+    <img class="inline-block mr-2" src="/images/icon/location.svg">
+    {{ .Params.location }}
+  </div>
+{{ end }}


### PR DESCRIPTION
Add the talks location to the talk card

*After*
![image](https://user-images.githubusercontent.com/1612785/71231985-00683900-22a5-11ea-9c41-a56419ccf0b5.png)

*Before*
![image](https://user-images.githubusercontent.com/1612785/71232002-1118af00-22a5-11ea-880f-1be6120c0196.png)
