### PR TITLE
Align titles and squiggly lines for top level pages

### DIFF
--- a/content/outreach/_index.md
+++ b/content/outreach/_index.md
@@ -7,5 +7,5 @@ menu:
   footer:
     weight: 6
 hasSquigglyLines: true
+description: "Our research takes place in the open as a combined effort with external researchers and the academic community.  These connections take many forms, depending on the field and the research direction."
 ---
-Our research takes place in the open as a combined effort with external researchers and the academic community.  These connections take many forms, depending on the field and the research direction.

--- a/layouts/about/list.html
+++ b/layouts/about/list.html
@@ -1,6 +1,5 @@
 {{ define "main" }}
   <div class="max-w-screen mx-auto pt-4 lg:pt-12 relative">
-    <h1 class="text-lg md:text-larger px-4 mb-8 md:px-12 lg:mb-0">About</h1>
 
     <img class="w-full -mb-56 lg:w-3/5 lg:absolute lg:mb-0 lg:right-0 lg:-mr-12 lg:top-0 lg:mt-12" src="/images/about-page/about-header@2x.jpg">
 

--- a/layouts/authors/list.html
+++ b/layouts/authors/list.html
@@ -2,7 +2,7 @@
 
 {{define "main"}}
 
-  <div class="max-w-screen mx-auto md:px-10">
+  <div class="max-w-screen mx-auto pt-4 md:px-10">
     {{ partial "page-top" . }}
 
     <div class="pt-10 lg:pt-40">

--- a/layouts/outreach/list.html
+++ b/layouts/outreach/list.html
@@ -1,15 +1,7 @@
 {{ define "main" }}
-  <div class="max-w-screen mx-auto md:px-10">
-    <div class="mb-4 lg:flex lg:pt-10">
-      <div class="pt-8 px-4 md:px-0 lg:w-2/3">
-        <div class="text-lg md:text-larger mb-4 leading-tight">
-          {{ .Title }}
-        </div>
-        <div class="font-light text-almost-black text-md">{{ .Content }}</div>
-      </div>
+<div class="max-w-screen mx-auto pt-4 md:px-10">
 
-      <img class="absolute right-0 hidden lg:block w-1/5" src="/images/small-squiggly-lines.svg">
-    </div>
+  {{ partial "page-top" . }}
 
     <div class="flex flex-col flex-wrap pt-16 mb-16 md:flex-row md:-mx-8">
       {{ range .RegularPages }}


### PR DESCRIPTION
Fixes inconsistent top margins for page titles and squiggly lines (on main menu pages)