### PR TITLE
Update signup form to send user to email type selection

### DIFF
--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -10,9 +10,9 @@
 
       <form
         class="outline-none relative w-full md:pl-4 max-w-sm flex-shrink-0 md:pb-2"
-        action="https://protocol.us4.list-manage.com/subscribe/post?u=09d704b0125b11d44d67d4617&amp;id=7aa0f1150b"
-        method="post"
-        name="mc-embedded-subscribe-form"
+        action="https://protocol.us4.list-manage.com/subscribe"
+        method="get"
+        name="mc-subscribe-form"
         target="_blank"
         novalidate
       >
@@ -21,12 +21,13 @@
           autocomplete="email"
           placeholder="youremailaddress@email.com"
           type="email"
-          name="EMAIL"
+          name="MERGE0"
           required
         >
 
         <div style="position: absolute; left: -5000px;" aria-hidden="true">
-          <input type="text" name="b_a1dfb670c4f1fb042e82a1f1d_d72d6318b0" tabindex="-1" value="">
+          <input type="text" name="u" tabindex="-1" value="09d704b0125b11d44d67d4617">
+          <input type="text" name="id" tabindex="-1" value="7aa0f1150b">
         </div>
 
         <button


### PR DESCRIPTION
Updates the signup form to pre-fill a Mailchimp-hosted signup form that allows for selection of the types of emails the user wants to receive (newsletter, announcements, other).