### PR TITLE
Add support for unaffiliated publications

### DIFF
--- a/archetypes/publications/index.md
+++ b/archetypes/publications/index.md
@@ -47,7 +47,7 @@ groups:
 
 # Publications without a PL affiliation can be added to the author's profile without showing up elsewhere
 # If adding one, set this to true *and* do not set an area or group
-no_affiliation: false
+unaffiliated: false
 
 # Publication pdf, should be in the same folder
 # No need to fill this out; just name the file the same as the folder

--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -2,7 +2,7 @@
 {{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
 {{- $pages := slice -}}
 {{- if or $.IsHome $.IsSection -}}
-{{- $pages = (where (where $pctx.RegularPages "Type" "in" "publications posts talks") ".Params.no_affiliation" "!=" true) -}}
+{{- $pages = (where (where $pctx.RegularPages "Type" "in" "publications posts talks") ".Params.unaffiliated" "!=" true) -}}
 {{- else -}}
 {{- $pages = $pctx.Pages -}}
 {{- end -}}

--- a/layouts/partials/home-page/updates-banner.html
+++ b/layouts/partials/home-page/updates-banner.html
@@ -5,7 +5,7 @@
   </div>
 
   <div class="flex flex-col md:flex-row md:flex-wrap items-start justify-start md:-mx-4">
-    {{range first 4 (where (where site.RegularPages "Type" "in" "publications posts talks") ".Params.no_affiliation" "!=" true)}}
+    {{range first 4 (where (where site.RegularPages "Type" "in" "publications posts talks") ".Params.unaffiliated" "!=" true)}}
       <a href="{{ .RelPermalink }}" class="block p-4 md:p-8 md:w-1/2 group">
         <p class="text-sm text-gray-700 mb-2">
           <span>{{ .Date.Format .Site.Params.DateForm }}</span>

--- a/layouts/publications/list.html
+++ b/layouts/publications/list.html
@@ -4,7 +4,7 @@
     {{ partial "page-top" . }}
 
     <div class="md:-mx-4 md:w-2/3">
-      {{ range where .RegularPages ".Params.no_affiliation" "!=" true}}
+      {{ range where .RegularPages ".Params.unaffiliated" "!=" true}}
         {{ partial "publication-card" . }}
       {{ end }}
     </div>


### PR DESCRIPTION
This makes it possible to add publications without a PL affiliation, by setting the `unaffiliated` flag. These will show in the author's profile but not in the global list, home page updates, or rss feed.

Closes #96 