### PR TITLE
Harmonise link rendering

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -162,6 +162,7 @@ figcaption {
 
 .page-content a:hover {
   @apply text-blue;
+  @apply underline;
 }
 
 .page-content p {

--- a/layouts/about/list.html
+++ b/layouts/about/list.html
@@ -11,8 +11,8 @@
 
       <div class="lg:flex">
         <div class="mb-12 lg:w-1/2 lg:mb-8">
-          <p class="font-light text-md leading-relaxed mb-8">We pursue diverse projects covering different timescales in multiple fields related to computation, communication, and knowledge. We work on pure applied research and use-inspired basic research, with an interest in expanding to pure basic research in the future. A clear perspective of our active research projects and future directions begins with a better understanding of where we’ve been.</p>
-          <a href="/research" class="hover:text-pink">Our research <img class="inline pl-2" src="/icons/chevron-pink.svg" alt=""></a>
+          <p class="font-light text-md leading-relaxed mb-6">We pursue diverse projects covering different timescales in multiple fields related to computation, communication, and knowledge. We work on pure applied research and use-inspired basic research, with an interest in expanding to pure basic research in the future. A clear perspective of our active research projects and future directions begins with a better understanding of where we’ve been.</p>
+          <a href="/research" class="text-blue hover:underline">Our research <img class="inline pl-2" src="/icons/chevron-pink.svg" alt=""></a>
         </div>
 
         <div class="max-w-sm md:mx-auto lg:w-1/2 lg:mt-40">
@@ -22,13 +22,13 @@
             {{ $author := . }}
             {{ range $author.Resources.Match "avatar" }}
               {{ $image := .Fill "56x56" }}
-              <a href="{{ $author.RelPermalink }}" class="flex items-center">
+              <div class="flex items-center">
                 <img class="mr-4 rounded rounded-full" src="{{ $image.RelPermalink }}">
                 <div class="">
                   <p class="leading-none pb-2">{{ $author.Params.name }}</p>
                   <p class="text-gray-700 text-sm">Research Team Lead</p>
                 </div>
-              </a>
+              </div>
             {{ end }}
           {{ end }}
         </div>
@@ -44,7 +44,7 @@
 
     <div class="lg:w-2/3 md:flex md:flex-row md:flex-wrap">
       <img class="p-4 max-w-screen mx-auto w-full bg-white mb-2" src="/images/about-page/pasteur-diagram.svg">
-      <div class="text-blue text-sm"><a href="https://en.wikipedia.org/wiki/Pasteur%27s_quadrant">Pasteur's Quadrant</a></div>
+      <div class="text-blue text-sm hover:underline"><a href="https://en.wikipedia.org/wiki/Pasteur%27s_quadrant">Pasteur's Quadrant</a></div>
     </div>
   </div>
 

--- a/layouts/authors/author.html
+++ b/layouts/authors/author.html
@@ -24,7 +24,7 @@
           {{ range (index .Params "groups")}}
             <span>/</span>
             {{ with $.Site.GetPage "taxonomyTerm" (printf "/groups/%s" (urlize . )) }}
-              <a href="{{ .RelPermalink }}" class="inline-block hover:text-blue hover:underline capitalize">
+              <a href="{{ .RelPermalink }}" class="inline-block hover:text-blue capitalize">
                 {{ .Title }}
               </a>
             {{ else }}
@@ -68,20 +68,20 @@
         {{ end }}
 
         {{ if .Pages }}
-          <h2 class="font-semibold mb-4 pt-8 hover:underline">Latest work</h2>
+          <h2 class="font-semibold mb-4 pt-8">Latest work</h2>
           <div class="">
             {{ range .Pages }}
-              <a href="{{ .RelPermalink }}" class="block mb-8 group">
+              <div class="block mb-8 group">
                 <p class="text-sm text-gray-700 mb-2">
                   <span>{{ .Date.Format .Site.Params.DateForm }}</span>
                   <span class="text-blue-200">/</span>
                   <span>{{ humanize .Type }}</span>
                 </p>
 
-                <h1 class="text-blue text-bigger leading-tight mb-2 group-hover:underline">{{ .Title }}</h1>
+                <h1 class="text-blue text-bigger leading-tight mb-2 hover:underline"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h1>
 
                 <p class="multiline-ellipsis-3">{{.Params.abstract | default .Summary }}</p>
-              </a>
+              </div>
             {{ end }}
           </div>
         {{ end }}

--- a/layouts/outreach/list.html
+++ b/layouts/outreach/list.html
@@ -12,7 +12,7 @@
           <div class="page-content mb-4">{{ .Summary }}</div>
 
           {{ if .Params.LinkUrl }}
-            <a class="hover:text-blue" href="{{ .Params.LinkUrl }}">{{ .Params.LinkText }} <img class="inline-block pl-2" src="/icons/chevron-pink.svg"></a>
+            <a class="text-blue hover:underline" href="{{ .Params.LinkUrl }}">{{ .Params.LinkText }} <img class="inline-block pl-2" src="/icons/chevron-pink.svg"></a>
           {{ end }}
         </div>
       {{ end }}

--- a/layouts/partials/author-card.html
+++ b/layouts/partials/author-card.html
@@ -5,7 +5,7 @@
 
     <img class="mx-auto -mt-4 w-64 h-64 md:w-48 md:h-48 mb-6 opacity-0 fade-in-twist group-hover:do-the-twist" src="/images/people-bg-mask.png">
   {{ end }}
-  <h3 class="text-center pb-2 text-almost-black font-semibold text-md leading-none group-hover:underline group-hover:text-blue">{{ .Params.name }}</h3>
+  <h3 class="text-center pb-2 text-blue font-semibold text-md leading-none group-hover:underline">{{ .Params.name }}</h3>
   <p class="text-center text-sm leading-loose">{{ .Params.email }}</p>
   <p class="text-center text-sm leading-loose">{{ .Params.role }}</p>
 </a>

--- a/layouts/partials/breadcrumbs-inner.html
+++ b/layouts/partials/breadcrumbs-inner.html
@@ -6,7 +6,7 @@
     {{ partial "breadcrumbs-inner" .Parent }}
   {{ end }}
 
-  <a class="inline capitalize hover:text-blue hover:underline" href="{{ .RelPermalink }}">{{(or .Params.name .Title )}}</a>
+  <a class="inline capitalize text-blue hover:underline" href="{{ .RelPermalink }}">{{(or .Params.name .Title )}}</a>
 
   {{ if .Pages }}
     <span class="inline">/</span>

--- a/layouts/partials/home-page/areas-banner.html
+++ b/layouts/partials/home-page/areas-banner.html
@@ -2,20 +2,20 @@
   <div class="mb-8 md:w-2/3 lg:w-1/3 lg:pr-8">
     <h2 class="font-bold text-md mb-4">Research areas</h2>
     <p class="mb-4">Our mission urges us to consider problems across multiple subject areas, both applied and theoretical.  We pursue these problems in the open and share our results in recorded talks and published papers.</p>
-    <a href="/research/areas"><span class="hover:underline">Learn more</span> <img src="/icons/chevron-pink.svg" class="inline-block ml-1"></a>
+    <a href="/research/areas"><span class="text-blue hover:underline">Learn more</span> <img src="/icons/chevron-pink.svg" class="inline-block ml-1"></a>
   </div>
 
   <div class="lg:w-2/3 md:flex md:flex-row md:flex-wrap">
     {{ range where (where .Site.Pages "Type" "areas") ".Kind" "==" "taxonomyTerm"}}
       {{ range .Pages }}
         <div class="pb-8 md:w-1/2 md:odd:pr-4 md:even:pl-4 md:self-stretch group">
-          <a href="{{ .RelPermalink }}" class="block relative bg-white p-4 border-black border-t md:p-8 md:h-full">
+          <div class="block relative bg-white p-4 border-black border-t md:p-8 md:h-full">
             {{ range .Resources.Match "icon.*" }}
               <img class="absolute right-0 top-0 mt-3 mr-4 md:-mt-2 md:-mr-2 md:relative md:inline-block md:float-right" width="36px" src="{{ .RelPermalink }}">
             {{ end }}
-            <h3 class="text-blue mb-4 text-bigger group-hover:underline">{{ .Title }}</h3>
+            <h3 class="text-blue mb-4 text-bigger hover:underline"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
             <p class="text-sm text-gray-700 multiline-ellipsis-6 overflow-hidden leading-relaxed">{{ .Summary }}</p>
-          </a>
+          </div>
         </div>
       {{end}}
     {{end}}

--- a/layouts/partials/home-page/updates-banner.html
+++ b/layouts/partials/home-page/updates-banner.html
@@ -6,7 +6,7 @@
 
   <div class="flex flex-col md:flex-row md:flex-wrap items-start justify-start md:-mx-4">
     {{range first 4 (where (where site.RegularPages "Type" "in" "publications posts talks") ".Params.unaffiliated" "!=" true)}}
-      <a href="{{ .RelPermalink }}" class="block p-4 md:p-8 md:w-1/2 group">
+      <div class="block p-4 md:p-8 md:w-1/2 group">
         <p class="text-sm text-gray-700 mb-2">
           <span>{{ .Date.Format .Site.Params.DateForm }}</span>
           <span class="text-blue-200">/</span>
@@ -14,10 +14,10 @@
           <span>{{ humanize .Type }}</span>
         </p>
 
-        <h1 class="text-blue text-bigger leading-tight group-hover:underline">{{ .Title }}</h1>
+        <h1 class="text-blue text-bigger leading-tight hover:underline mb-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h1>
 
         <div class="multiline-ellipsis-3 md:multiline-ellipsis-3">{{ .Params.abstract | default .Summary }}</div>
-      </a>
+      </div>
     {{end}}
   </div>
 </div>

--- a/layouts/partials/post-card.html
+++ b/layouts/partials/post-card.html
@@ -1,7 +1,7 @@
 <div class="px-4 pt-8 mb-6">
   {{ partial "post-data-strip" . }}
 
-  <a class="block text-bigger text-blue leading-tight mb-2 pt-2" href="{{ .RelPermalink }}">{{ .Title }}</a>
+  <a class="block text-bigger text-blue leading-tight mb-2 pt-2 hover:underline" href="{{ .RelPermalink }}">{{ .Title }}</a>
 
   <div class="mb-2 multiline-ellipsis-4">
     {{ .Summary }}

--- a/layouts/partials/publication-card.html
+++ b/layouts/partials/publication-card.html
@@ -1,7 +1,7 @@
 <div class="p-4">
   {{partial "publication-data-strip" . }}
 
-  <a class="block text-bigger text-blue leading-tight mb-2 pt-2" href="{{ .RelPermalink }}">{{ .Title }}</a>
+  <a class="block text-bigger text-blue hover:underline leading-tight mb-2 pt-2" href="{{ .RelPermalink }}">{{ .Title }}</a>
 
   <div class="mb-2 multiline-ellipsis-4">
     {{ .Summary }}

--- a/layouts/partials/research-taxonomy-card-half.html
+++ b/layouts/partials/research-taxonomy-card-half.html
@@ -1,6 +1,6 @@
 <div class="p-4 md:p-8 md:w-1/2">
     <div class="flex flex-row items-center justify-start mb-4">
-      <a class="text-md leading-relaxed hover:text-blue" href="{{ .RelPermalink }}">{{ .Title }}</a>
+      <a class="text-md leading-relaxed text-blue hover:underline" href="{{ .RelPermalink }}">{{ .Title }}</a>
       {{ range .Resources.Match "icon.*" }}
           <img class="ml-auto mr-2" width="36px" src="{{ .RelPermalink }}">
       {{ end }}

--- a/layouts/partials/research-taxonomy-card.html
+++ b/layouts/partials/research-taxonomy-card.html
@@ -3,7 +3,7 @@
       {{ range .Resources.Match "icon.*" }}
         <img class="mr-4" width="36px" src="{{ .RelPermalink }}">
       {{ end }}
-      <a class="text-md leading-relaxed hover:text-blue" href="{{ .RelPermalink }}">{{ .Title }}</a>
+      <a class="text-md leading-relaxed text-blue hover:underline" href="{{ .RelPermalink }}">{{ .Title }}</a>
     </div>
     <p class="mb-4">{{ .Summary }}</p>
 </div>

--- a/layouts/partials/resources-box.html
+++ b/layouts/partials/resources-box.html
@@ -13,7 +13,7 @@
   {{ range .Resources.Match "*.pdf" }}
     <div class="mb-4 pl-4 md:pl-8">
       <img class="inline-block mr-2" src="/icons/download.svg">
-      <a class="text-blue inline-block inline-middle text-sm" href="{{ .RelPermalink }}">Download PDF</a>
+      <a class="text-blue inline-block inline-middle text-sm hover:underline" href="{{ .RelPermalink }}">Download PDF</a>
     </div>
   {{ end }}
 

--- a/layouts/partials/share-box.html
+++ b/layouts/partials/share-box.html
@@ -8,17 +8,17 @@
 
   <div class="mb-4 pl-4 md:pl-8">
     <img class="inline-block pr-2 inline-middle" src="/images/talks-page/mail-icon.svg">
-    <a href="mailto:?subject=Check%20out%20{{ $title }}.&body={{ $body }}" class="text-blue inline-block inline-middle text-sm" aria-label="share on Email">Share via Email</a>
+    <a href="mailto:?subject=Check%20out%20{{ $title }}.&body={{ $body }}" class="text-blue inline-block inline-middle text-sm hover:underline" aria-label="share on Email">Share via Email</a>
   </div>
 
   <div class="mb-4 pl-4 md:pl-8">
     <img class="inline-block pr-2 inline-middle" src="/images/talks-page/twitter-icon.svg">
-    <a href="http://twitter.com/intent/tweet?text={{ $body }}" class="text-blue inline-block inline-middle text-sm" aria-label="share on Twitter">Share on Twitter</a>
+    <a href="http://twitter.com/intent/tweet?text={{ $body }}" class="text-blue inline-block inline-middle text-sm hover:underline" aria-label="share on Twitter">Share on Twitter</a>
   </div>
 
   <div class="pl-4 md:pl-8">
     <img class="inline-block pr-2 inline-middle" src="/images/talks-page/linkedin-icon.svg">
-    <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ $url }}&title={{ $title }}&summary={{ $body }}&source={{ .Site.BaseURL }}" class="text-blue inline-block inline-middle text-sm" aria-label="share on LinkedIn">Share on LinkedIn</a>
+    <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ $url }}&title={{ $title }}&summary={{ $body }}&source={{ .Site.BaseURL }}" class="text-blue inline-block inline-middle text-sm hover:underline" aria-label="share on LinkedIn">Share on LinkedIn</a>
   </div>
 
 </div>

--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -22,7 +22,7 @@
             {{end}}
 
             {{if or ($currentPage.IsMenuCurrent "main" .) ($currentPage.HasMenuCurrent "main" .) (in $currentPage.RelPermalink .URL) }}
-              <div class="absolute inset-x-0 bottom-0 border border-black"></div>
+              <div class="absolute inset-x-0 border border-black"></div>
             {{end}}
           </a>
 
@@ -33,7 +33,7 @@
                   <span>{{ .Name }}</span>
 
                   {{if or ($currentPage.IsMenuCurrent "main" .) ($currentPage.HasMenuCurrent "main" .) (in $currentPage.RelPermalink .URL) }}
-                    <div class="absolute inset-x-0 bottom-0 border border-white"></div>
+                    <div class="absolute inset-x-0 border border-white"></div>
                   {{end}}
                 </a>
               {{ end }}

--- a/layouts/partials/talk-card.html
+++ b/layouts/partials/talk-card.html
@@ -11,7 +11,7 @@
     {{ end }}
   </a>
 
-  <a class="block text-bigger text-blue leading-tight mb-2 pt-2" href="{{ .RelPermalink }}">{{ .Title }}</a>
+  <a class="block text-bigger text-blue hover:underline leading-tight mb-2 pt-2" href="{{ .RelPermalink }}">{{ .Title }}</a>
 
   {{ partial "page-metadata" . }}
 </div>

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -20,25 +20,25 @@
         <div class="flex flex-row justify-between">
 
           {{ if .NextInSection }}
-            <a class="block mb-8 md:w-1/2 group" href="{{ .NextInSection.RelPermalink }}">
+            <div class="block mb-8 md:w-1/2 group">
               <div class="font-bold">
                 <img class="inline-block align-middle rotate-180 mr-2" src="/icons/chevron-pink.svg">
                 <span class="align-middle">Newer</span>
               </div>
 
-              <div class="pl-5 text-blue group-hover:underline">{{ .NextInSection.Title }}</div>
-            </a>
+              <div class="pl-5 text-blue hover:underline"><a href="{{ .NextInSection.RelPermalink }}">{{ .NextInSection.Title }}</a></div>
+            </div>
           {{ end }}
 
           {{ if .PrevInSection }}
-            <a class="block pl-4 md:w-1/2 text-right ml-auto group" href="{{ .PrevInSection.RelPermalink }}">
+            <div class="block pl-4 md:w-1/2 text-right ml-auto group">
               <span class="w-1/2 font-bold ml-auto order-2">
                 <span class="align-middle">Older</span>
                 <img class="inline-block align-middle ml-2" src="/icons/chevron-pink.svg">
               </span>
 
-              <div class="pr-5 text-blue group-hover:underline">{{ .PrevInSection.Title }}</div>
-            </a>
+              <div class="pr-5 text-blue hover:underline"><a href="{{ .PrevInSection.RelPermalink }}">{{ .PrevInSection.Title }}</a></div>
+            </div>
           {{ end }}
         </div>
       </div>


### PR DESCRIPTION
Harmonises link rendering, mostly moving towards blue text and underline on hover (this was already the most common choice). Other styles were kept where appropriate (e.g. post metadata with grey and blue on hoover). Also deletes some group-hovers, which were used inconsistently. 

Closes #120 