### PR TITLE
Re-list Guy's role

### DIFF
--- a/content/authors/guy-wuollet/_index.md
+++ b/content/authors/guy-wuollet/_index.md
@@ -3,7 +3,7 @@
 name: "Guy Wuollet"
 
 # Role/position (e.g. Research Scientist)
-role: "Research Intern"
+role: "Research Assistant"
 
 # Avatar (no need to edit)
 resources:


### PR DESCRIPTION
Apparently we can't have "interns" at PL for legal/compliance reasons, so we need to make sure this (and future) short-term individual contributor positions are not officially listed as interns.