### PR TITLE
Update project assignment action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,4 +22,4 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'blog')
       with:
         project: 'https://github.com/protocol/research-website/projects/1'
-        column_name: 'Upcoming'
+        column_name: 'New'


### PR DESCRIPTION
This is the last PR, I swear.

This is [working](https://github.com/protocol/research-website/issues/197) now. Every time something gets labelled "blog" (which happens automatically per the issue template, or manually), things get added to the "New" column in the [GitHub project](https://github.com/protocol/research-website/projects/1). Afterwards, one can drag them to the "Upcoming" column, dropping them into their rightful place in the queue. Re-sequencing posts is just drag and drop. When closed/merged, they automatically moved to "Done". If we adhere to a consistent cadence of 1/week while the pipeline is full, then the depth in the "Upcoming" column is just weeks to publication.

We don't have to use it. It's a potential way to solve a problem that was identified with high visibility, little manual labour (just placing things in the proper place in the queue, which we were doing anyway), and no extra tooling.

@KarolaKirsanow @jpgross3 