### PR TITLE
Update licence to CC-BY 4.0

### DIFF
--- a/content/terms-of-service/index.md
+++ b/content/terms-of-service/index.md
@@ -6,9 +6,9 @@ Our content licensing policies are based on those of the [Google Developer websi
 
 We are pleased to license much of the content and documentation available on our sites under terms that explicitly encourage people to take, modify, reuse, re-purpose, and remix our work as they see fit.
 
-You will find the following notice at the bottom of many pages on the Google Developers website:
+You will find the following notice at the bottom of our pages:
 
-Except as noted, content licensed CC-BY 3.0, code licensed MIT.
+> Except as noted, content licensed CC-BY 4.0.
 
 When you see a page with this notice you are free to use nearly everything on the page in your own creations. That's what open content licenses are all about. We just ask that you give us attribution when you reuse our work.
 
@@ -22,7 +22,7 @@ In some cases, a page may include content consisting of images, audio or video m
 
 ## ATTRIBUTION
 
-Proper attribution is required when you reuse or create modified versions of content that appears on a page made available under the terms of the Creative Commons Attribution license. The complete requirements for attribution can be found in section 4 of the [Creative Commons legal code](https://creativecommons.org/licenses/by/3.0/legalcode).
+Proper attribution is required when you reuse or create modified versions of content that appears on a page made available under the terms of the Creative Commons Attribution license. The complete requirements for attribution can be found in section 3 of the [Creative Commons legal code](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 In practice we ask that you provide attribution to Protocol Labs to the best of the ability of the medium in which you are producing the work.
 
@@ -32,7 +32,7 @@ There are several typical ways in which this might apply:
 
 If your online work exactly reproduces text or images from this site, in whole or in part, please include a paragraph at the bottom of your page, or wherever convenient, that reads:
 
-Portions of this page are reproduced from work created and shared by Protocol Labs and used according to terms described in the [Creative Commons 3.0 Attribution License](https://creativecommons.org/licenses/by/3.0/legalcode).
+Portions of this page are reproduced from work created and shared by Protocol Labs and used according to terms described in the [Creative Commons 4.0 Attribution License](https://creativecommons.org/licenses/by/4.0/).
 
 Also, please link back to the original source page so that readers can refer to it for more information.
 
@@ -40,7 +40,7 @@ Also, please link back to the original source page so that readers can refer to 
 
 If your online work shows modified text or images based on the content from this site, please include a paragraph at the bottom of your page that reads:
 
-Portions of this page are modifications based on work created and shared by Protocol Labs and used according to terms described in the [Creative Commons 3.0 Attribution License](https://creativecommons.org/licenses/by/3.0/legalcode).
+Portions of this page are modifications based on work created and shared by Protocol Labs and used according to terms described in the [Creative Commons 4.0 Attribution License](https://creativecommons.org/licenses/by/4.0/).
 
 Again, please link back to the original source page so that readers can refer to it for more information. This is even more important when the content has been modified.
 

--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -75,7 +75,7 @@
         </a>
       </div>
 
-      <div class="w-full text-sm text-gray-600 md:w-auto md:mr-auto">© Protocol Labs, Inc. | Except as <a href="/terms-of-service" class="inline-block underline">noted</a>, content licensed <a href="https://creativecommons.org/licenses/by/3.0/" class="inline-block underline">CC-BY 3.0.</a> | <a href="/terms-of-service" class="inline-block underline">Terms of service</a> | <a href="/privacy-policy" class="inline-block underline">Privacy policy</a></div>
+      <div class="w-full text-sm text-gray-600 md:w-auto md:mr-auto">© Protocol Labs, Inc. | Except as <a href="/terms-of-service" class="inline-block underline">noted</a>, content licensed <a href="https://creativecommons.org/licenses/by/4.0/" class="inline-block underline">CC-BY 4.0.</a> | <a href="/terms-of-service" class="inline-block underline">Terms of service</a> | <a href="/privacy-policy" class="inline-block underline">Privacy policy</a></div>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
Updates license from legacy CC-BY 3.0 to 4.0, which has some [improvements](https://creativecommons.org/version4/) (mostly clarity) and better international porting, while keeping permitted uses unchanged.