### PR TITLE
Update research-jobs.md

### DIFF
--- a/content/outreach/research-jobs.md
+++ b/content/outreach/research-jobs.md
@@ -4,6 +4,6 @@ nositemap: false
 weight: 6
 title: Research Jobs
 linkText: Browse current openings
-linkUrl: "https://jobs.lever.co/protocol/?"
+linkUrl: "https://jobs.lever.co/protocol/"
 ---
-The mission of Protocol Labs Research is to pursue open, collaborative, high-impact research that pushes the boundaries of what computing can do for humanity, and we are looking for people who share this vision and are willing to work hard to get there. As a distributed team, we hire anywhere in the world, and at various levels of experience (entry, senior, staff). We look for people with unique perspectives and diverse backgrounds. Use the "Location" filter on our job board to toggle between jobs in "[PL Research](https://jobs.lever.co/protocol/?location=Remote%20-%20PL%20Research)" and "[Research Development](https://jobs.lever.co/protocol/?location=Remote%20-%20Research%20Development)."
+The mission of Protocol Labs Research is to pursue open, collaborative, high-impact research that pushes the boundaries of what computing can do for humanity, and we are looking for people who share this vision and are willing to work hard to get there. As a distributed team, we hire anywhere in the world, and at various levels of experience (entry, senior, staff). We look for people with unique perspectives and diverse backgrounds."


### PR DESCRIPTION
There is no way to filter multiple "locations" at the same time, and this wording (however awkward) seemed to be the best way to ensure people see all relevant jobs without having to see ALL jobs. 