### PR TITLE
Add open jobs blog post

### DIFF
--- a/content/posts/202105-hiring/index.md
+++ b/content/posts/202105-hiring/index.md
@@ -28,17 +28,10 @@ areas:
 
 # Zero or more of the groups in content/groups (should match author membership)
 groups:
-<<<<<<< HEAD
   - cryptocomputelab
   - cryptoeconlab
   - cryptonetlab
   - resnetlab
-=======
-  - CryptoComputeLab
-  - CryptoEconLab
-  - CryptoNetLab
-  - ResNetLab
->>>>>>> 1fd4459832d6d56c9f8d436c7d6b1dc7242a21c6
 
 # Not used
 draft: false


### PR DESCRIPTION
Individual jobs not linked because of Lever's future 404s. 

Remember to update date when it goes up.