### PR TITLE
Add mailing list banner

### DIFF
--- a/layouts/partials/home-page/event-banner.html
+++ b/layouts/partials/home-page/event-banner.html
@@ -1,5 +1,8 @@
-{{ $show_banner := false}}
-{{ if $show_banner }}
+{{- /* <!-- Is there an active event banner? Set this to true --> */ -}}
+{{ $show_event_banner := false}}
+
+{{- /* <!-- Configure event text here --> */ -}}
+{{ if $show_event_banner }}
 <div class="relative overflow-hidden text-white mb-20" data-removal-target>
   <img class="object-cover h-full w-full absolute" src="/images/banners/event-banner@2x.jpg" >
 
@@ -16,6 +19,30 @@
     <div class="flex-shrink-0 md:ml-4">
       <button class="text-sm bg-transparent font-semibold py-2 px-3 border border-white-500 rounded shadow">
         <a href="/blog/2021/call-for-participation-di2f-decentralizing-the-internet-with-ipfs-and-filecoin/">Read more</a>
+        <img class="inline-block ml-2" src="/icons/chevron-white.svg" alt="">
+      </button>
+    </div>
+  </div>
+</div>
+{{ end }}
+
+{{- /* <!-- If no event, default to mailing list message --> */ -}}
+{{ if not $show_event_banner }}
+<div class="relative overflow-hidden text-white mb-20" data-removal-target>
+  <img class="object-cover h-full w-full absolute" src="/images/banners/event-banner@2x.jpg" >
+
+  <div class="relative max-w-screen mx-auto z-10 flex flex-col p-4 md:flex-row md:items-center md:px-10 md:py-8 md:justify-between">
+    <img on-click="removeParentTargetFromDom" class="absolute right-0 top-4 mr-4 md:top-0 lg:-mr-8 p-1 md:p-4" src="/images/icon/close.png" alt="Close button">
+
+    <div class="mb-4 md:pr-4 md:mb-0">
+      <h2 class="leading-tight font-bold text-md">Want to be in the loop? Join our mailing list.</h2>
+    </div>
+
+    <p class="hidden md:block max-w-sm px-4 leading-normal text-sm">Sign up for quarterly newsletters, funding opportunities, and more: the newest Protocol Labs Research questions and ideas, delivered straight to your inbox!</p>
+
+    <div class="flex-shrink-0 md:ml-4">
+      <button class="text-sm bg-transparent font-semibold py-2 px-3 border border-white-500 rounded shadow">
+        <a href="https://mailchi.mp/protocol/research-newsletter-signup">Subscribe</a>
         <img class="inline-block ml-2" src="/icons/chevron-white.svg" alt="">
       </button>
     </div>


### PR DESCRIPTION
Implements @miyazono's idea from a while back to repurpose the home page banner as a mailing list advertisement when not in use for an event.