### PR TITLE
Switch to ISO 8601 dates

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -19,7 +19,7 @@ params:
   Author: "Protocol Labs Research"
   Description: "Protocol Labs Research explores the future of decentralization and examines the infrastructure limiting what you can do with technology."
   Locale: "en_US"
-  TwitterUser: "@protocollabs"
+  TwitterUser: "@ProtoResearch"
 permalinks:
   talks: /talks/:title/
   publications: /publications/:title/


### PR DESCRIPTION
Currently the blog is using dates in the form of "year.month.day".
This is confusing for folks like me, who come from an area where
dates are also written with a dot as separator, but a different
order: "day.month.year".

Hence it makes sense to display dates in the format of the ISO 8601
standard: year-month-day (with leading zeros).