### PR TITLE
Add CryptoComputeLab alias

### DIFF
--- a/content/groups/cryptocomputelab/_index.md
+++ b/content/groups/cryptocomputelab/_index.md
@@ -10,6 +10,7 @@ resources:
 
 aliases:
   - /research/groups/filecoin-research
+  - /research/groups/cryptocomputelab
 ---
 
  ## Mission & Vision


### PR DESCRIPTION
The CryptoComputeLab blog posts link to
https://research.protocol.ai/research/groups/cryptocomputelab/
which cannot be found as it has been moved to
https://research.protocol.ai/groups/cryptocomputelab/

As cool URLs don't change, add an alias to make it work again.