### PR TITLE
Add @ProtoResearch link to footer

### DIFF
--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -5,7 +5,7 @@
       <div class="flex flex-col items-start md:pr-4 flex-grow">
         <div class="text-md leading-cavernous font-bold">Stay Informed</div>
 
-        <p class="pb-8 md:pb-0 w-4/5">Subscribe to our <a class="underline" href="/index.xml">RSS feed</a>, follow <a href="https://twitter.com/ProtoResearch">@ProtoResearch</a> on Twitter, or sign up for quarterly newsletters, funding opportunities, and more: the newest Protocol Labs Research questions and ideas, delivered straight to your inbox. Previous newsletters available in the <a class="underline" href="https://us4.campaign-archive.com/home/?u=09d704b0125b11d44d67d4617&id=7aa0f1150b">archive</a>.</p>
+        <p class="pb-8 md:pb-0 w-4/5">Subscribe to our <a class="underline" href="/index.xml">RSS feed</a>, follow <a class="underline" href="https://twitter.com/ProtoResearch">@ProtoResearch</a> on Twitter, or sign up for quarterly newsletters, funding opportunities, and more: the newest Protocol Labs Research questions and ideas, delivered straight to your inbox. Previous newsletters available in the <a class="underline" href="https://us4.campaign-archive.com/home/?u=09d704b0125b11d44d67d4617&id=7aa0f1150b">archive</a>.</p>
       </div>
 
       <form


### PR DESCRIPTION
I just realised we haven't added any links from the website to Twitter. I suggest:
- [x] Mentioning Twitter in the"Stay informed" message
- [x] Adding a Twitter link to the footer, next to GitHub