### PR TITLE
Update join link after move to GreenHouse

### DIFF
--- a/content/outreach/research-jobs.md
+++ b/content/outreach/research-jobs.md
@@ -4,6 +4,6 @@ nositemap: false
 weight: 6
 title: Research jobs
 linkText: Browse current openings
-linkUrl: "https://jobs.lever.co/protocol/"
+linkUrl: "https://protocol.ai/join/"
 ---
 The mission of Protocol Labs Research is to pursue open, collaborative, high-impact research that pushes the boundaries of what computing can do for humanity, and we are looking for people who share this vision and are willing to work hard to get there. As a distributed team, we hire anywhere in the world, and at various levels of experience (entry, senior, staff). We look for people with unique perspectives and diverse backgrounds."


### PR DESCRIPTION
The move from Lever to GreenHouse broke our join link. This replaces it with just a link to protocol.ai/join.