### PR TITLE
Fix modifying phrase error

### DIFF
--- a/content/posts/202202-liz-welcome/index.md
+++ b/content/posts/202202-liz-welcome/index.md
@@ -38,7 +38,7 @@ draft: false
 
 ---
 
-After Pennsylvania, Scotland, and Ireland, we're happy to welcome [Liz Bryson](/authors/liz-bryson) to Protocol Labs as our newest Research Administrator. 
+We are excited to welcome [Liz Bryson](/authors/liz-bryson) as a Research Administrator at Protocol Labs.  
 
 We asked Liz about what brought her to Protocol Labs, the projects she'll be working on, and her thoughts on future technological developments:
 


### PR DESCRIPTION
Not just picking nits here. The current wording's [grammar is wrong](http://www.entrytest.com/englishgrammar/agr06.aspx) and needs to change. If we want to keep references to Penn, Scotland, and Ireland, we'll need to reword it (FWIW she is also still living in PA).