### PR TITLE
Update research page

### DIFF
--- a/layouts/research/list.html
+++ b/layouts/research/list.html
@@ -12,7 +12,7 @@
     </div>
     <div class="flex flex-col md:flex-row md:flex-wrap md:-mx-8 mb:12">
     {{ range where (where .Site.Pages "Type" "groups") ".Kind" "==" "taxonomy"}}
-      {{ range .Pages }}
+      {{ range sort ((where .Pages ".Params.archived" "!=" true)) ".Title" "asc"}}
         {{ partial "research-taxonomy-card-half" .}}
       {{ end }}
     {{ end }}
@@ -28,7 +28,7 @@
     </div>
     <div class="flex flex-col md:flex-row md:flex-wrap md:-mx-8">
     {{ range where (where .Site.Pages "Type" "areas") ".Kind" "==" "taxonomy"}}
-      {{ range .Pages }}
+      {{ range sort ((where .Pages ".Params.archived" "!=" true)) ".Title" "asc"}}
         {{ partial "research-taxonomy-card-half" .}}
       {{ end }}
     {{ end }}


### PR DESCRIPTION
Turns out I forgot to update the /research page in #593. Instead of listing both active and previous, I chose to only list the active ones in that overview page, as anything else would look weird + people can still go to groups or areas to see old ones.