### PR TITLE
2022 Recap

### DIFF
--- a/content/posts/202212-recap/index.md
+++ b/content/posts/202212-recap/index.md
@@ -1,0 +1,40 @@
+---
+# Blog post title
+title: "Protocol Labs Research Recap"
+
+# Website post date
+# format YYYY-MM-DD
+date: 2022-12-24
+
+# Publish from this date (defaults to date)
+# publishDate: 2019-09-03
+
+# For PL authors, use author folder name; for non-PL authors, write name as in paper within ""
+# We sort authors alphabetically by last name
+authors:
+  - abby-silin
+
+# If applicable
+categories:
+  - blog
+  - events
+
+# If applicable
+tags:
+
+
+# Zero or more of the areas in content/areas
+areas:
+  - networking
+  
+# Zero or more of the groups in content/groups (should match author membership)
+groups:
+  - network-goods
+  - research-acceleration
+  - 
+
+# Not used
+draft: true
+
+---
+


### PR DESCRIPTION
If no December blog topic requests, this can be backup. @liam-ohagan please let me know if this overlaps with any upcoming newsletters and I can adjust. This will be PL Research-focused

A "Year in Review" blog

## Highlighting:
 - number of events held
 - number of new PL Research teammates
 - number of papers published by researchers?
 - General mention of collaborations such as advisorships

## Year to come:
 - Planned events if resources have been made public
 - Possibly highlight additional considerations w/grant applications (stricter review process)
 - highlight repo, website, social media for updates