### PR TITLE
Fix grants blog post

### DIFF
--- a/content/posts/202301-pause-grants/index.md
+++ b/content/posts/202301-pause-grants/index.md
@@ -21,22 +21,22 @@ categories:
   - blog
 
 # If applicable
-#tags:
-  - RFPs
-  - Grants
+# tags:
+#   - RFPs
+#   - Grants
 
 # Zero or more of the areas in content/areas
-areas:
-  - networking
+# areas:
+#   - networking
 
 # Zero or more of the groups in content/groups (should match author membership)
-#groups:
-  - consensuslab
-  - cryptoeconlab
-  - cryptonet
-  - network-research
-  - probelab
-  - research-acceleration
+# groups:
+#   - consensuslab
+#   - cryptoeconlab
+#   - cryptonet
+#   - network-research
+#   - probelab
+#   - research-acceleration
 
 # Not used
 draft: false


### PR DESCRIPTION
I _think_ we tried to comment out the groups and tags but commented out just the keys, which led to groups being interpreted as areas and tags being interpreted as categories. This broke not just the blog post

![image](https://user-images.githubusercontent.com/547492/215627206-2c511c79-da8f-4103-b362-f2f037d7e61e.png)

But the homepage too

![image](https://user-images.githubusercontent.com/547492/215627243-f3a27882-7725-4edb-af77-e330882a3942.png)

This really should have been caught in PR review.
